### PR TITLE
end2end CPU support

### DIFF
--- a/main_end2end.py
+++ b/main_end2end.py
@@ -68,7 +68,7 @@ opt_parser = parser.parse_args()
 
 ''' STEP 1: preprocess input single image '''
 img =cv2.imread('examples/' + opt_parser.jpg)
-predictor = face_alignment.FaceAlignment(face_alignment.LandmarksType._3D, device='cuda', flip_input=True)
+predictor = face_alignment.FaceAlignment(face_alignment.LandmarksType._3D, device="cuda" if torch.cuda.is_available() else "cpu", flip_input=True)
 shapes = predictor.get_landmarks(img)
 if (not shapes or len(shapes) != 1):
     print('Cannot detect face landmarks. Exit.')

--- a/src/approaches/train_audio2landmark.py
+++ b/src/approaches/train_audio2landmark.py
@@ -55,7 +55,10 @@ class Audio2landmark_model():
         print('G: Running on {}, total num params = {:.2f}M'.format(device, get_n_params(self.G)/1.0e6))
 
         model_dict = self.G.state_dict()
-        ckpt = torch.load(opt_parser.load_a2l_G_name)
+        if device.type == "cpu":
+            ckpt = torch.load(opt_parser.load_a2l_G_name, map_location=torch.device("cpu"))
+        else:
+            ckpt = torch.load(opt_parser.load_a2l_G_name)
         pretrained_dict = {k: v for k, v in ckpt['G'].items() if k.split('.')[0] not in ['comb_mlp']}
         model_dict.update(pretrained_dict)
         self.G.load_state_dict(model_dict)
@@ -68,7 +71,11 @@ class Audio2landmark_model():
                                       in_size=80, use_prior_net=True,
                                       bidirectional=False, drop_out=0.5)
 
-        ckpt = torch.load(opt_parser.load_a2l_C_name)
+        if device.type == "cpu":
+            ckpt = torch.load(opt_parser.load_a2l_C_name, map_location=torch.device("cpu"))
+        else:
+            ckpt = torch.load(opt_parser.load_a2l_C_name)
+            
         self.C.load_state_dict(ckpt['model_g_face_id'])
         # self.C.load_state_dict(ckpt['C'])
         print('======== LOAD PRETRAINED FACE ID MODEL {} ========='.format(opt_parser.load_a2l_C_name))

--- a/src/approaches/train_image_translation.py
+++ b/src/approaches/train_image_translation.py
@@ -42,7 +42,10 @@ class Image_translation_block():
             self.G = ResUnetGenerator(input_nc=6, output_nc=3, num_downs=6, use_dropout=False)
 
         if (opt_parser.load_G_name != ''):
-            ckpt = torch.load(opt_parser.load_G_name)
+            if torch.cuda.is_available():
+                ckpt = torch.load(opt_parser.load_G_name)
+            else:
+                ckpt = torch.load(opt_parser.load_G_name, map_location=torch.device("cpu"))
             try:
                 self.G.load_state_dict(ckpt['G'])
             except:

--- a/src/models/model_audio2landmark.py
+++ b/src/models/model_audio2landmark.py
@@ -242,7 +242,10 @@ class DecoderLayer(nn.Module):
 
         self.attn_1 = MultiHeadAttention(heads, d_model)
         self.attn_2 = MultiHeadAttention(heads, d_model)
-        self.ff = FeedForward(d_model).cuda()
+        if device.type == "cpu":
+            self.ff = FeedForward(d_model)
+        else:
+            self.ff = FeedForward(d_model).cuda()
 
     def forward(self, x, e_outputs, src_mask, trg_mask):
         x2 = self.norm_1(x)


### PR DESCRIPTION
### Added CPU-only devices support

## Description
- main_end2end now checks if "cuda" is not available, and if so, defaults to CPU.

## Motivation and Context
- Now allows inferencing on devices with no cuda-enabled GPUs

## How Has This Been Tested?
- Tested locally on custom animations

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.